### PR TITLE
Add support for Qt 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,40 @@
 cmake_minimum_required(VERSION 3.24)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+include_directories(
+    ${CMAKE_CURRENT_BINARY_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
 if(QT_VERSION_MAJOR EQUAL 6)
+    qt_add_qml_module(QmlHttpRequest
+        URI "QmlHttpRequest"
+        OUTPUT_DIRECTORY
+            ${CMAKE_BINARY_DIR}/QmlHttpRequest
+        VERSION 0.3
+        SOURCES
+            src/qmlhttprequest_global.hpp
+            src/request.hpp src/request.cpp
+            src/qmlhttprequest.hpp src/qmlhttprequest.cpp
+            src/response.hpp src/response.cpp
+        )
 
+    # This is required on Windows and MSVC
+    target_link_directories(${PROJECT_NAME} PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+    # Next line is required for Qml Preview on Linux to be able to load the module
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        QmlHttpRequest
+    )
 else()
-    project(qmlHttpRequest VERSION 0.3 LANGUAGES CXX)
-
-    set(CMAKE_CXX_STANDARD 17)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    project(QmlHttpRequest VERSION 0.3 LANGUAGES CXX)
 
     find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Network Qml)
-
-    include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
     add_library(${PROJECT_NAME} SHARED
         src/qmlhttprequest_global.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if(QT_VERSION_MAJOR EQUAL 6)
     # This is required on Windows and MSVC
     target_link_directories(${PROJECT_NAME} PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}/QmlHttpRequest
     )
 
     # Next line is required for Qml Preview on Linux to be able to load the module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(QT_VERSION_MAJOR EQUAL 6)
         URI "QmlHttpRequest"
         OUTPUT_DIRECTORY
             ${CMAKE_BINARY_DIR}/QmlHttpRequest
-        VERSION 0.3
+        VERSION 1.3
         SOURCES
             src/qmlhttprequest_global.hpp
             src/request.hpp src/request.cpp
@@ -32,7 +32,7 @@ if(QT_VERSION_MAJOR EQUAL 6)
         QmlHttpRequest
     )
 else()
-    project(QmlHttpRequest VERSION 0.3 LANGUAGES CXX)
+    project(QmlHttpRequest VERSION 1.3 LANGUAGES CXX)
 
     find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Network Qml)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,16 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+set(QHR_VERSION
+    1.4
+)
+
 if(QT_VERSION_MAJOR EQUAL 6)
     qt_add_qml_module(QmlHttpRequest
         URI "QmlHttpRequest"
         OUTPUT_DIRECTORY
             ${CMAKE_BINARY_DIR}/QmlHttpRequest
-        VERSION 1.3
+        VERSION ${QHR_VERSION}
         SOURCES
             src/qmlhttprequest_global.hpp
             src/request.hpp src/request.cpp
@@ -33,7 +37,7 @@ if(QT_VERSION_MAJOR EQUAL 6)
         QmlHttpRequest
     )
 else()
-    project(QmlHttpRequest VERSION 1.3 LANGUAGES CXX)
+    project(QmlHttpRequest VERSION ${QHR_VERSION} LANGUAGES CXX)
 
     find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Network Qml)
 

--- a/src/qmlhttprequest.cpp
+++ b/src/qmlhttprequest.cpp
@@ -19,6 +19,15 @@ QmlHttpRequest& QmlHttpRequest::singleton()
     return qhr;
 }
 
+#if QT_VERSION_MAJOR == 6
+QmlHttpRequest* QmlHttpRequest::create(QQmlEngine* qmlEngine, QJSEngine* jsEngine)
+{
+    auto instance = &QmlHttpRequest::singleton();
+    QJSEngine::setObjectOwnership(instance, QJSEngine::CppOwnership);
+    return instance;
+}
+#endif
+
 QmlHttpRequest::QmlHttpRequest(QObject* parent)
     : QObject { parent },
       mNam(new QNetworkAccessManager())

--- a/src/qmlhttprequest.cpp
+++ b/src/qmlhttprequest.cpp
@@ -9,6 +9,16 @@ namespace qhr {
  * can be used in QML to create a new \ref Request
  */
 
+/*!
+ * \brief Returns the singleton instance of \ref QmlHttpRequest
+ * \return
+ */
+QmlHttpRequest& QmlHttpRequest::singleton()
+{
+    static QmlHttpRequest qhr;
+    return qhr;
+}
+
 QmlHttpRequest::QmlHttpRequest(QObject* parent)
     : QObject { parent },
       mNam(new QNetworkAccessManager())

--- a/src/qmlhttprequest.cpp
+++ b/src/qmlhttprequest.cpp
@@ -63,4 +63,16 @@ QmlHttpRequest::RedirectPolicy QmlHttpRequest::redirectPolicy() const
     return RedirectPolicy(mNam->redirectPolicy());
 }
 
+#if QT_VERSION_MAJOR == 5
+void registerQmlHttpRequestMethods()
+{
+    qmlRegisterSingletonInstance(
+        "qmlhttprequest", 1, 0, "QmlHttpRequest", &QmlHttpRequest::singleton());
+    qmlRegisterUncreatableType<qhr::Request>("qmlhttprequest", 1, 0,
+        "Request", "Request can not be created from QML");
+}
+
+Q_COREAPP_STARTUP_FUNCTION(registerQmlHttpRequestMethods)
+#endif
+
 }

--- a/src/qmlhttprequest.hpp
+++ b/src/qmlhttprequest.hpp
@@ -24,32 +24,40 @@
 #define QMLHTTPREQUEST_HPP
 
 #include <QNetworkAccessManager>
-#include <QSharedPointer>
-#include <QQmlEngine>
 #include <QObject>
+#include <QQmlEngine>
+#include <QSharedPointer>
+
+#include "request.hpp"
 
 namespace qhr {
-
-class Request;
 
 class QmlHttpRequest : public QObject
 {
     Q_OBJECT
     QML_ELEMENT
-    Q_PROPERTY(RedirectPolicy redirectPolicy READ redirectPolicy WRITE setRedirectPolicy)
+    QML_SINGLETON
+    Q_PROPERTY(RedirectPolicy redirectPolicy READ redirectPolicy WRITE
+            setRedirectPolicy)
 
     using QNetworkAccessManagerPtr = QSharedPointer<QNetworkAccessManager>;
+
 public:
-    enum RedirectPolicy {
+    enum RedirectPolicy
+    {
         ManualRedirectPolicy = QNetworkRequest::ManualRedirectPolicy,
         NoLessSafeRedirectPolicy = QNetworkRequest::NoLessSafeRedirectPolicy,
         SameOriginRedirectPolicy = QNetworkRequest::SameOriginRedirectPolicy,
-        UserVerifiedRedirectPolicy = QNetworkRequest::UserVerifiedRedirectPolicy,
+        UserVerifiedRedirectPolicy
+        = QNetworkRequest::UserVerifiedRedirectPolicy,
     };
     Q_ENUM(RedirectPolicy)
 
 public:
     static QmlHttpRequest& singleton();
+#if QT_VERSION_MAJOR == 6
+    static QmlHttpRequest* create(QQmlEngine* qmlEngine, QJSEngine* jsEngine);
+#endif
 
     Q_INVOKABLE qhr::Request* newRequest();
     Q_INVOKABLE void setDefaultTimeout(int timeout);

--- a/src/qmlhttprequest.hpp
+++ b/src/qmlhttprequest.hpp
@@ -48,13 +48,18 @@ public:
     };
     Q_ENUM(RedirectPolicy)
 
-    explicit QmlHttpRequest(QObject* parent = nullptr);
+public:
+    static QmlHttpRequest& singleton();
 
     Q_INVOKABLE qhr::Request* newRequest();
     Q_INVOKABLE void setDefaultTimeout(int timeout);
 
     void setRedirectPolicy(RedirectPolicy rp);
     RedirectPolicy redirectPolicy() const;
+
+protected:
+    explicit QmlHttpRequest(QObject* parent = nullptr);
+
 private:
     QNetworkAccessManagerPtr mNam;
 };

--- a/src/qmlhttprequest.hpp
+++ b/src/qmlhttprequest.hpp
@@ -57,7 +57,11 @@ public:
     void setRedirectPolicy(RedirectPolicy rp);
     RedirectPolicy redirectPolicy() const;
 
+#ifdef QHR_TEST
 protected:
+#else
+private:
+#endif
     explicit QmlHttpRequest(QObject* parent = nullptr);
 
 private:

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -312,8 +312,6 @@ void Request::addBodyDataToMultipart(
              it != bodyMap.constKeyValueEnd(); ++it) {
             QHttpPart part;
 
-            qDebug() << "key: " << prefix + it->first;
-
             switch (it->second.type()) {
             case int(QMetaType::QString): {
                 if (QUrl url = it->second.toUrl();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ function(add_new_gtest testname)
             Qt${QT_VERSION_MAJOR}::Network
             gtest
             gmock
-            qmlHttpRequest
+            QmlHttpRequest
         )
         target_include_directories(${testname} PRIVATE ../src)
     else()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ function(add_new_gtest testname)
         )
         add_test(NAME "test_${testname}" COMMAND ${testname})
 
+        add_compile_definitions(QHR_TEST)
         target_link_libraries(${testname} PRIVATE
             Qt${QT_VERSION_MAJOR}::Qml
             Qt${QT_VERSION_MAJOR}::Core

--- a/tests/tst_qmlhttprequest.cpp
+++ b/tests/tst_qmlhttprequest.cpp
@@ -6,10 +6,13 @@
 #include "qmlhttprequest.hpp"
 #include "request.hpp"
 
+class QmlHttpRequestTestable : public qhr::QmlHttpRequest
+{ };
+
 class TestQmlHttpRequest : public ::testing::Test
 {
 public:
-    qhr::QmlHttpRequest qhr;
+    QmlHttpRequestTestable qhr;
 };
 
 TEST_F(TestQmlHttpRequest, TestNewRequest)


### PR DESCRIPTION
Tested on Linux with Qt 6.3.2
- Add Support for Qt 6
- Make QmlHttpRequest a singleton and provide instance through static `singleton()` method