### PR TITLE
Fix Request instances not being destroyed

### DIFF
--- a/src/qmlhttprequest.cpp
+++ b/src/qmlhttprequest.cpp
@@ -44,7 +44,7 @@ QmlHttpRequest::QmlHttpRequest(QObject* parent)
  */
 Request* QmlHttpRequest::newRequest()
 {
-    return new Request(mNam, mNam->transferTimeout(), this);
+    return new Request(mNam);
 }
 
 /*!

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -27,8 +27,8 @@ namespace qhr {
  * \param parent
  */
 Request::Request(QNetworkAccessManagerPtr nam, int timeout)
+    : mNam(nam), mMethodName(""), mMethod(Method::INVALID), mNReply(nullptr)
 {
-    mNam = nam;
     if (timeout != 0) {
         mNRequest.setTransferTimeout(timeout);
     }

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -20,24 +20,13 @@ namespace qhr {
  */
 
 /*!
- * \brief Create an invalid, not-open \ref Request object
- * \param parent
- */
-Request::Request(QObject* parent)
-    : QObject { parent }, mNam(QNetworkAccessManagerPtr()), mMethodName(""),
-      mMethod(Method::INVALID), mNReply(nullptr)
-{
-}
-
-/*!
  * \brief Initialize an object of this calss inject \a nam as \a\b
  * QNetworkAccessManager and \a timeout for transfert timeout
  * \param nam
  * \param timeout
  * \param parent
  */
-Request::Request(QNetworkAccessManagerPtr nam, int timeout, QObject* parent)
-    : Request(parent)
+Request::Request(QNetworkAccessManagerPtr nam, int timeout)
 {
     mNam = nam;
     if (timeout != 0) {
@@ -156,11 +145,6 @@ void Request::abort()
         mResponse.statusText = "";
         mResponse.responseText = "{ \"detail\": \"Operation aborted\" }";
     }
-}
-
-void Request::destroy()
-{
-    deleteLater();
 }
 
 bool Request::isOpen() const

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -139,8 +139,6 @@ void Request::abort()
             mNReply->abort();
         }
 
-        mNReply->deleteLater();
-
         mResponse.status = 0;
         mResponse.statusText = "";
         mResponse.responseText = "{ \"detail\": \"Operation aborted\" }";

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -404,7 +404,7 @@ void Request::multipartAddValue(
             part.setHeader(QNetworkRequest::ContentTypeHeader, mimeType.name());
             part.setHeader(QNetworkRequest::ContentDispositionHeader,
                 QString("form-data; name=\"" + prefix + "\"; filename=\"%1\"")
-                    .arg(file->fileName()));
+                    .arg(url.fileName()));
             part.setBodyDevice(file);
 
             // Set file parent to mpBody so it deleted automatically

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -86,9 +86,7 @@ public:
     };
     Q_ENUM(State);
 
-    explicit Request(QObject* parent = nullptr);
-    Request(QNetworkAccessManagerPtr nam, int timeout = 0,
-        QObject* parent = nullptr);
+    Request(QNetworkAccessManagerPtr nam, int timeout = 0);
     virtual ~Request();
 
     Q_INVOKABLE void open(const QString& method, const QUrl& url);
@@ -96,7 +94,6 @@ public:
         const QString& header, const QString& value);
     Q_INVOKABLE void send(const QVariant& body = QVariant());
     Q_INVOKABLE void abort();
-    Q_INVOKABLE void destroy();
 
     bool isOpen() const;
 


### PR DESCRIPTION
- Remove setting parent of a **Request** instance so the QML engine destroys it when it is not referenced anymore
- Fix occasional crash caused by calling `deleteLater()` on `mNReply` after calling to `abort()`, since `onReplyFinished()` delete it already