### PR TITLE
Fix QmlHttpRequest making the program crash and freeze in Qt5 after closing.

### DIFF
--- a/src/qmlhttprequest.cpp
+++ b/src/qmlhttprequest.cpp
@@ -13,21 +13,22 @@ namespace qhr {
 
 void QmlHttpRequest::registerQmlHttpRequest()
 {
-    qmlRegisterSingletonInstance(PROJECT_NAME, PROJECT_VERSION_MAJOR,
-        PROJECT_VERSION_MINOR, "QmlHttpRequest", &QmlHttpRequest::singleton());
+    qmlRegisterSingletonType<QmlHttpRequest>(PROJECT_NAME,
+        PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, "QmlHttpRequest",
+        [](QQmlEngine* engine, QJSEngine* script) -> QmlHttpRequest* {
+            if (auto engineNam = engine->networkAccessManager()) {
+                auto instance = new QmlHttpRequest;
+                instance->setNetworkAccessManager(engineNam);
+
+                QQmlEngine::setObjectOwnership(
+                    instance, QQmlEngine::JavaScriptOwnership);
+                return instance;
+            }
+            return nullptr;
+        });
     qmlRegisterUncreatableType<qhr::Request>("QmlHttpRequest",
         PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, "Request",
         "Request can not be created from QML");
-}
-
-/*!
- * \brief Returns the singleton instance of \ref QmlHttpRequest
- * \return
- */
-QmlHttpRequest& QmlHttpRequest::singleton()
-{
-    static QmlHttpRequest qhr;
-    return qhr;
 }
 
 #if QT_VERSION_MAJOR == 6
@@ -39,11 +40,6 @@ QmlHttpRequest* QmlHttpRequest::create(
     return instance;
 }
 #endif
-
-QmlHttpRequest::QmlHttpRequest(QObject* parent)
-    : QObject { parent }, mNam(new QNetworkAccessManager())
-{
-}
 
 /*!
  * \brief QmlHttpRequest::newRequest() Creates a new \ref Request object that
@@ -65,6 +61,16 @@ Request* QmlHttpRequest::newRequest()
 void QmlHttpRequest::setDefaultTimeout(int timeout)
 {
     mNam->setTransferTimeout(timeout);
+}
+
+void QmlHttpRequest::setNetworkAccessManager(QNetworkAccessManager *nam)
+{
+    mNam = nam;
+}
+
+QNetworkAccessManager *QmlHttpRequest::networkAccessManager() const
+{
+    return mNam;
 }
 
 /*!

--- a/src/qmlhttprequest.cpp
+++ b/src/qmlhttprequest.cpp
@@ -17,8 +17,7 @@ void QmlHttpRequest::registerQmlHttpRequest()
         PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, "QmlHttpRequest",
         [](QQmlEngine* engine, QJSEngine* script) -> QmlHttpRequest* {
             if (auto engineNam = engine->networkAccessManager()) {
-                auto instance = new QmlHttpRequest;
-                instance->setNetworkAccessManager(engineNam);
+                auto instance = new QmlHttpRequest(engineNam);
 
                 QQmlEngine::setObjectOwnership(
                     instance, QQmlEngine::JavaScriptOwnership);
@@ -35,11 +34,21 @@ void QmlHttpRequest::registerQmlHttpRequest()
 QmlHttpRequest* QmlHttpRequest::create(
     QQmlEngine* qmlEngine, QJSEngine* jsEngine)
 {
-    auto instance = &QmlHttpRequest::singleton();
-    QJSEngine::setObjectOwnership(instance, QJSEngine::CppOwnership);
-    return instance;
+    if (auto engineNam = qmlEngine->networkAccessManager()) {
+        auto instance = new QmlHttpRequest(engineNam);
+
+        QQmlEngine::setObjectOwnership(
+            instance, QQmlEngine::JavaScriptOwnership);
+        return instance;
+    }
+    return nullptr;
 }
 #endif
+
+QmlHttpRequest::QmlHttpRequest(QNetworkAccessManager* nam)
+    : QObject { nullptr }, mNam { nam }
+{
+}
 
 /*!
  * \brief QmlHttpRequest::newRequest() Creates a new \ref Request object that

--- a/src/qmlhttprequest.cpp
+++ b/src/qmlhttprequest.cpp
@@ -11,6 +11,7 @@ namespace qhr {
  * can be used in QML to create a new \ref Request
  */
 
+#if QT_VERSION_MAJOR == 5
 void QmlHttpRequest::registerQmlHttpRequest()
 {
     qmlRegisterSingletonType<QmlHttpRequest>(PROJECT_NAME,
@@ -29,6 +30,7 @@ void QmlHttpRequest::registerQmlHttpRequest()
         PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, "Request",
         "Request can not be created from QML");
 }
+#endif
 
 #if QT_VERSION_MAJOR == 6
 QmlHttpRequest* QmlHttpRequest::create(

--- a/src/qmlhttprequest.hpp
+++ b/src/qmlhttprequest.hpp
@@ -40,8 +40,6 @@ class QmlHttpRequest : public QObject
     Q_PROPERTY(RedirectPolicy redirectPolicy READ redirectPolicy WRITE
             setRedirectPolicy)
 
-    using QNetworkAccessManagerPtr = QSharedPointer<QNetworkAccessManager>;
-
 public:
     enum RedirectPolicy
     {
@@ -65,26 +63,23 @@ public:
 public:
     static void registerQmlHttpRequest();
 
-    static QmlHttpRequest& singleton();
 #if QT_VERSION_MAJOR == 6
     static QmlHttpRequest* create(QQmlEngine* qmlEngine, QJSEngine* jsEngine);
 #endif
 
+    QmlHttpRequest() = default;
+
     Q_INVOKABLE qhr::Request* newRequest();
     Q_INVOKABLE void setDefaultTimeout(int timeout);
+
+    void setNetworkAccessManager(QNetworkAccessManager* nam);
+    QNetworkAccessManager* networkAccessManager() const;
 
     void setRedirectPolicy(RedirectPolicy rp);
     RedirectPolicy redirectPolicy() const;
 
-#ifdef QHR_TEST
-protected:
-#else
 private:
-#endif
-    explicit QmlHttpRequest(QObject* parent = nullptr);
-
-private:
-    QNetworkAccessManagerPtr mNam;
+    QNetworkAccessManager* mNam;
 };
 
 }

--- a/src/qmlhttprequest.hpp
+++ b/src/qmlhttprequest.hpp
@@ -61,7 +61,9 @@ public:
     Q_ENUM(State);
 
 public:
+#if QT_VERSION_MAJOR == 5
     static void registerQmlHttpRequest();
+#endif
 
 #if QT_VERSION_MAJOR == 6
     static QmlHttpRequest* create(QQmlEngine* qmlEngine, QJSEngine* jsEngine);

--- a/src/qmlhttprequest.hpp
+++ b/src/qmlhttprequest.hpp
@@ -67,7 +67,7 @@ public:
     static QmlHttpRequest* create(QQmlEngine* qmlEngine, QJSEngine* jsEngine);
 #endif
 
-    QmlHttpRequest() = default;
+    QmlHttpRequest(QNetworkAccessManager* nam);
 
     Q_INVOKABLE qhr::Request* newRequest();
     Q_INVOKABLE void setDefaultTimeout(int timeout);

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -61,8 +61,6 @@ class QHR_EXPORT Request : public QObject
     Q_PROPERTY(QJSValue ontimeout           MEMBER  mTimeoutCb)
     Q_PROPERTY(QJSValue onerror             MEMBER  mErrorCb)
 
-    using QNetworkAccessManagerPtr = QSharedPointer<QNetworkAccessManager>;
-
 public:
     enum class Method : char
     {
@@ -86,7 +84,7 @@ public:
     };
     Q_ENUM(State);
 
-    Request(QNetworkAccessManagerPtr nam, int timeout = 0);
+    Request(QNetworkAccessManager* nam, int timeout = 0);
     virtual ~Request();
 
     Q_INVOKABLE void open(const QString& method, const QUrl& url);
@@ -99,7 +97,7 @@ public:
 
     QByteArray requestHeader(const QByteArray& header) const;
 
-    void setNetworkAccessManager(QNetworkAccessManagerPtr nam);
+    void setNetworkAccessManager(QNetworkAccessManager* nam);
     auto networkAccessManager() const { return mNam; }
 
     void setTimeout(int timeout);
@@ -142,7 +140,7 @@ private:
     void onReplyUploadProgress(qint64 bytesSent, qint64 bytesTotal);
 
 private:
-    QNetworkAccessManagerPtr mNam;
+    QNetworkAccessManager* mNam;
     QNetworkRequest mNRequest;
     QNetworkReply* mNReply;
     QByteArray mMethodName;

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -42,6 +42,7 @@ class QHR_EXPORT Request : public QObject
 {
     Q_OBJECT
     QML_ELEMENT
+    QML_UNCREATABLE("Request can not be created from QML")
     // Response properties
     Q_PROPERTY(QVariant response        READ response       CONSTANT)
     Q_PROPERTY(QString  responseText    READ responseText   CONSTANT)


### PR DESCRIPTION
The reason was using `static` instances for passing `QmlHttpRequest` to *QML*. By using `qmlRegisterSingletonType` instead of `qmlRegisterSingletonInstance` and providing an instance of `QmlHttpRequest` and passing its ownership to QML engine, the responsibility for deleting this instance would be passed to it, which solves the freeze and crash problem after closing the program running `QmlHttpRequest`.